### PR TITLE
Changes how child resources are instantiated

### DIFF
--- a/src/Rest/ChildResource.php
+++ b/src/Rest/ChildResource.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Strawberry\Shopify\Rest;
 
+use Strawberry\Shopify\Http\Client;
+
 abstract class ChildResource extends Resource
 {
     /**
@@ -14,34 +16,21 @@ abstract class ChildResource extends Resource
     protected $parentId;
 
     /**
-     * The parent resource for this resource.
+     * The parent instance.
      *
-     * @var string
+     * @var Resource
      */
     protected $parent;
 
     /**
-     * Fluently set the resource's parent ID.
-     *
-     * @param  int|string  $id
-     *
-     * @return $this
+     * @param  int|string  $parentId
      */
-    public function withParent($id)
+    public function __construct(Client $client, Resource $parent, $parentId)
     {
-        $this->parentId = $id;
+        parent::__construct($client);
 
-        return $this;
-    }
-
-    /**
-     * Return an instance of the parent class.
-     */
-    protected function getParentInstance(): Resource
-    {
-        $parent = $this->parent;
-
-        return new $parent($this->client);
+        $this->parent = $parent;
+        $this->parentId = $parentId;
     }
 
     /**
@@ -51,6 +40,6 @@ abstract class ChildResource extends Resource
     {
         $uri = substr(parent::uri($uri), 0, -5);
 
-        return $this->getParentInstance()->uri("/{$this->parentId}/{$uri}");
+        return $this->parent->uri("/{$this->parentId}/{$uri}");
     }
 }

--- a/src/Rest/Resource.php
+++ b/src/Rest/Resource.php
@@ -95,9 +95,11 @@ abstract class Resource
     /**
      * Return an instance of the child resource with the given key.
      *
+     * @param int|string  $id
+     *
      * @throws ClientException
      */
-    public function getChild(string $key): ChildResource
+    public function getChild(string $key, $id): ChildResource
     {
         if (! $this->hasChild($key)) {
             throw ClientException::childDoesntExist(static::class, $key);
@@ -105,7 +107,7 @@ abstract class Resource
 
         $resource = $this->childResources[$key];
 
-        return new $resource($this->client);
+        return new $resource($this->client, $this, $id);
     }
 
     public function singularResourceKey(): string

--- a/src/Rest/ResourceProxy.php
+++ b/src/Rest/ResourceProxy.php
@@ -35,8 +35,6 @@ class ResourceProxy
      */
     public function __call(string $method, array $params): ChildResource
     {
-        return $this->resourceClass
-            ->getChild($method)
-            ->withParent($this->resourceId);
+        return $this->resourceClass->getChild($method, $this->resourceId);
     }
 }

--- a/src/Rest/Resources/Billing/UsageCharge.php
+++ b/src/Rest/Resources/Billing/UsageCharge.php
@@ -15,13 +15,6 @@ final class UsageChargeResource extends ChildResource
         Concerns\CreatesResource;
 
     /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = RecurringApplicationChargeResource::class;
-
-    /**
      * The model that represents this resource.
      *
      * @var string

--- a/src/Rest/Resources/Customers/AddressResource.php
+++ b/src/Rest/Resources/Customers/AddressResource.php
@@ -17,13 +17,6 @@ final class AddressResource extends ChildResource
         Concerns\DeletesResource;
 
     /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = CustomerResource::class;
-
-    /**
      * The model that represents this resource.
      *
      * @var string

--- a/src/Rest/Resources/Discounts/BatchResource.php
+++ b/src/Rest/Resources/Discounts/BatchResource.php
@@ -16,13 +16,6 @@ final class BatchResource extends ChildResource
         Concerns\FindsResource;
 
     /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = PriceRuleResource::class;
-
-    /**
      * The model that represents this resource.
      *
      * @var string

--- a/src/Rest/Resources/Discounts/DiscountCodeResource.php
+++ b/src/Rest/Resources/Discounts/DiscountCodeResource.php
@@ -17,13 +17,6 @@ final class DiscountCodeResource extends ChildResource
         Concerns\DeletesResource;
 
     /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = PriceRuleResource::class;
-
-    /**
      * The model that represents this resource.
      *
      * @var string

--- a/src/Rest/Resources/OnlineStore/AssetResource.php
+++ b/src/Rest/Resources/OnlineStore/AssetResource.php
@@ -20,13 +20,6 @@ final class AssetResource extends ChildResource
     protected $model = Asset::class;
 
     /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = ThemeResource::class;
-
-    /**
      * Retrieves a single asset for a theme by its key.
      */
     public function find(string $key, array $options = []): Asset

--- a/src/Rest/Resources/OnlineStore/BlogArticleResource.php
+++ b/src/Rest/Resources/OnlineStore/BlogArticleResource.php
@@ -25,13 +25,6 @@ final class BlogArticleResource extends ChildResource
     protected $model = Article::class;
 
     /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = BlogResource::class;
-
-    /**
      * Retrieves a list of all tags from a specific blog.
      *
      * @return string[]

--- a/src/Rest/Resources/OnlineStore/BlogResource.php
+++ b/src/Rest/Resources/OnlineStore/BlogResource.php
@@ -30,6 +30,6 @@ final class BlogResource extends Resource
      * @var string[]
      */
     protected $childResources = [
-        'articles' => ArticleResource::class,
+        'articles' => BlogArticleResource::class,
     ];
 }

--- a/src/Rest/Resources/Orders/OrderResource.php
+++ b/src/Rest/Resources/Orders/OrderResource.php
@@ -7,6 +7,7 @@ namespace Strawberry\Shopify\Rest\Resources\Orders;
 use Strawberry\Shopify\Models\Orders\Order;
 use Strawberry\Shopify\Rest\Concerns;
 use Strawberry\Shopify\Rest\Resource;
+use Strawberry\Shopify\Rest\Resources\Shipping\FulfillmentResource;
 
 final class OrderResource extends Resource
 {
@@ -30,8 +31,9 @@ final class OrderResource extends Resource
      * @var string[]
      */
     protected $childResources = [
-        'risks' => OrderRiskResource::class,
+        'fulfillments' => FulfillmentResource::class,
         'refunds' => RefundResource::class,
+        'risks' => OrderRiskResource::class,
         'transactions' => TransactionResource::class,
     ];
 

--- a/src/Rest/Resources/Orders/OrderRiskResource.php
+++ b/src/Rest/Resources/Orders/OrderRiskResource.php
@@ -23,13 +23,6 @@ final class OrderRiskResource extends ChildResource
      */
     protected $model = OrderRisk::class;
 
-    /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = OrderResource::class;
-
     public function singularResourceKey(): string
     {
         return 'risk';

--- a/src/Rest/Resources/Orders/RefundResource.php
+++ b/src/Rest/Resources/Orders/RefundResource.php
@@ -22,13 +22,6 @@ final class RefundResource extends ChildResource
     protected $model = Refund::class;
 
     /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = OrderResource::class;
-
-    /**
      * Calculates a refund.
      */
     public function calculate(array $data): Refund

--- a/src/Rest/Resources/Orders/TransactionResource.php
+++ b/src/Rest/Resources/Orders/TransactionResource.php
@@ -21,11 +21,4 @@ final class TransactionResource extends ChildResource
      * @var string
      */
     protected $model = Transaction::class;
-
-    /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = OrderResource::class;
 }

--- a/src/Rest/Resources/Products/ImageResource.php
+++ b/src/Rest/Resources/Products/ImageResource.php
@@ -23,11 +23,4 @@ final class ImageResource extends ChildResource
      * @var string
      */
     protected $model = Image::class;
-
-    /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = ProductResource::class;
 }

--- a/src/Rest/Resources/Products/ProductVariantResource.php
+++ b/src/Rest/Resources/Products/ProductVariantResource.php
@@ -21,11 +21,4 @@ final class ProductVariantResource extends ChildResource
      * @var string
      */
     protected $model = Variant::class;
-
-    /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = ProductResource::class;
 }

--- a/src/Rest/Resources/Sales/PaymentResource.php
+++ b/src/Rest/Resources/Sales/PaymentResource.php
@@ -21,11 +21,4 @@ final class PaymentResource extends ChildResource
      * @var string
      */
     protected $model = Payment::class;
-
-    /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = CheckoutResource::class;
 }

--- a/src/Rest/Resources/Shipping/FulfillmentEventResource.php
+++ b/src/Rest/Resources/Shipping/FulfillmentEventResource.php
@@ -22,13 +22,6 @@ final class FulfillmentEventResource extends ChildResource
      */
     protected $model = FulfillmentEvent::class;
 
-    /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = FulfillmentResource::class;
-
     public function routeKey(): string
     {
         return 'events';

--- a/src/Rest/Resources/Shipping/FulfillmentEventResource.php
+++ b/src/Rest/Resources/Shipping/FulfillmentEventResource.php
@@ -28,4 +28,9 @@ final class FulfillmentEventResource extends ChildResource
      * @var string
      */
     protected $parent = FulfillmentResource::class;
+
+    public function routeKey(): string
+    {
+        return 'events';
+    }
 }

--- a/src/Rest/Resources/Shipping/FulfillmentResource.php
+++ b/src/Rest/Resources/Shipping/FulfillmentResource.php
@@ -25,13 +25,6 @@ final class FulfillmentResource extends ChildResource
     protected $model = Fulfillment::class;
 
     /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = OrderResource::class;
-
-    /**
      * A list of the child resources.
      *
      * @var string[]

--- a/src/Rest/Resources/Store/ProvinceResource.php
+++ b/src/Rest/Resources/Store/ProvinceResource.php
@@ -21,11 +21,4 @@ final class ProvinceResource extends ChildResource
      * @var string
      */
     protected $model = Province::class;
-
-    /**
-     * The parent resource for this resource.
-     *
-     * @var string
-     */
-    protected $parent = CountryResource::class;
 }

--- a/tests/Stubs/Resources/ChildResourceStub.php
+++ b/tests/Stubs/Resources/ChildResourceStub.php
@@ -13,9 +13,6 @@ final class ChildResourceStub extends ChildResource
     /** @var string */
     protected $model = ModelStub::class;
 
-    /** @var string */
-    protected $parent = ResourceStub::class;
-
     public function getParentId(): int
     {
         return $this->parentId;

--- a/tests/Unit/Rest/ChildResourceTest.php
+++ b/tests/Unit/Rest/ChildResourceTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use Strawberry\Shopify\Tests\TestCase;
 use Strawberry\Shopify\Rest\ChildResource;
 use Strawberry\Shopify\Tests\Stubs\Resources\ChildResourceStub;
+use Strawberry\Shopify\Tests\Stubs\Resources\ResourceStub;
 
 final class ChildResourceTest extends TestCase
 {
@@ -26,14 +27,8 @@ final class ChildResourceTest extends TestCase
             'handler' => HandlerStack::create($this->mockHandler)
         ]));
 
-        $this->resource = new ChildResourceStub($client);
-    }
-
-    public function testWithParent(): void
-    {
-        $this->resource->withParent(123456789);
-
-        $this->assertSame(123456789, $this->resource->getParentId());
+        $parent = new  ResourceStub($client);
+        $this->resource = new ChildResourceStub($client, $parent, 123456789);
     }
 
     public function testUri(): void
@@ -42,7 +37,7 @@ final class ChildResourceTest extends TestCase
             201, [], '{"model_stub":{"foo":"bar"}}'
         ));
 
-        $this->resource->withParent(123456789)->create(['foo' => 'bar']);
+        $this->resource->create(['foo' => 'bar']);
 
         $request = $this->mockHandler->getLastRequest();
         $this->assertSame('model_stubs/123456789/model_stubs.json', (string) $request->getUri());

--- a/tests/Unit/Rest/ResourceProxyTest.php
+++ b/tests/Unit/Rest/ResourceProxyTest.php
@@ -24,11 +24,7 @@ final class ResourceProxyTest extends TestCase
         $proxy = new ResourceProxy($this->resource, 123456789);
 
         $this->resource->shouldReceive('getChild')
-            ->with('childResource')
-            ->andReturn($this->childResource);
-
-        $this->childResource->shouldReceive('withParent')
-            ->with(123456789)
+            ->with('childResource', 123456789)
             ->andReturn($this->childResource);
 
         $proxy->childResource();

--- a/tests/Unit/Rest/ResourceTest.php
+++ b/tests/Unit/Rest/ResourceTest.php
@@ -168,12 +168,12 @@ final class ResourceTest extends TestCase
     {
         $this->expectException(ClientException::class);
 
-        $this->resource->getChild('foo');
+        $this->resource->getChild('foo', 123456789);
     }
 
     public function testGetChild(): void
     {
-        $child = $this->resourceWithChildren->getChild('child');
+        $child = $this->resourceWithChildren->getChild('child', 123456789);
 
         $this->assertInstanceOf(ChildResourceStub::class, $child);
     }

--- a/tests/Unit/Rest/Resources/Billing/UsageChargeResourceTest.php
+++ b/tests/Unit/Rest/Resources/Billing/UsageChargeResourceTest.php
@@ -3,13 +3,19 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Billing;
 
 use Strawberry\Shopify\Models\Billing\UsageCharge;
+use Strawberry\Shopify\Rest\Resources\Billing\RecurringApplicationChargeResource;
 use Strawberry\Shopify\Rest\Resources\Billing\UsageChargeResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class UsageChargeResourceTest extends ResourceTestCase
+final class UsageChargeResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = UsageCharge::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [RecurringApplicationChargeResource::class, 1034618216],
+    ];
 
     /** @var string */
     protected $resourceClass = UsageChargeResource::class;
@@ -17,15 +23,16 @@ final class UsageChargeResourceTest extends ResourceTestCase
     /** @var string */
     protected $dataPath = 'billing/usage_charge';
 
+
     public function testCreate(): void
     {
         $this->queue(200, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'recurring_application_charges/123456789/usage_charges.json');
+        $this->assertRequest('POST', 'recurring_application_charges/1034618216/usage_charges.json');
         $this->assertModel($response);
     }
 
@@ -33,9 +40,9 @@ final class UsageChargeResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(1034618216);
+        $response = $this->resource->find(1034618216);
 
-        $this->assertRequest('GET', 'recurring_application_charges/123456789/usage_charges/1034618216.json');
+        $this->assertRequest('GET', 'recurring_application_charges/1034618216/usage_charges/1034618216.json');
         $this->assertModel($response);
     }
 
@@ -43,11 +50,11 @@ final class UsageChargeResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(1034618216, [
+        $response = $this->resource->find(1034618216, [
             'fields' => 'id,description'
         ]);
 
-        $this->assertRequest('GET', 'recurring_application_charges/123456789/usage_charges/1034618216.json?fields=id,description');
+        $this->assertRequest('GET', 'recurring_application_charges/1034618216/usage_charges/1034618216.json?fields=id,description');
         $this->assertModel($response);
     }
 
@@ -55,9 +62,9 @@ final class UsageChargeResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'recurring_application_charges/123456789/usage_charges.json');
+        $this->assertRequest('GET', 'recurring_application_charges/1034618216/usage_charges.json');
         $this->assertCollection($response);
     }
 
@@ -65,11 +72,11 @@ final class UsageChargeResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get([
+        $response = $this->resource->get([
             'fields' => 'id,description'
         ]);
 
-        $this->assertRequest('GET', 'recurring_application_charges/123456789/usage_charges.json?fields=id,description');
+        $this->assertRequest('GET', 'recurring_application_charges/1034618216/usage_charges.json?fields=id,description');
         $this->assertCollection($response);
     }
 }

--- a/tests/Unit/Rest/Resources/ChildResourceTestCase.php
+++ b/tests/Unit/Rest/Resources/ChildResourceTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Strawberry\Shopify\Tests\Unit\Rest\Resources;
+
+use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Collection;
+use Strawberry\Shopify\Http\Client;
+use Strawberry\Shopify\Rest\ChildResource;
+use Strawberry\Shopify\Rest\Resource;
+use Strawberry\Shopify\Tests\Concerns\MocksRequests;
+
+abstract class ChildResourceTestCase extends ResourceTestCase
+{
+    use MocksRequests;
+
+    /**
+     * The stack of parent resources. Each item is an array with two values;
+     * the parent resource and the ID for testing. The final item in the
+     * array is the direct parent of the resource that's being tested.
+     *
+     * @var array[]
+     */
+    protected $parentResources = [
+        ['Grandparent', 1],
+        ['Parent', 2],
+    ];
+
+    public function setUpTestCase(): void
+    {
+        $this->mockHandler = new MockHandler();
+        $this->client = new Client(new GuzzleHttpClient([
+            'handler' => HandlerStack::create($this->mockHandler),
+            'allow_redirects' => true,
+        ]));
+
+        $this->resource = $this->setUpResource();
+    }
+
+    private function setUpResource(): ChildResource
+    {
+        [$parent, $parentId] = $this->setUpParentResource();
+
+        $resourceClass = $this->resourceClass;
+        return new $resourceClass($this->client, $parent, $parentId);
+    }
+
+    private function setUpParentResource(): array
+    {
+        return array_reduce($this->parentResources, function (
+            ?array $parent,
+            array $item
+        ) {
+            [$resource, $id] = $item;
+
+            $resource = $parent
+                ? new $resource($this->client, ...$parent)
+                : new $resource($this->client);
+
+            return [$resource, $id];
+        });
+    }
+}

--- a/tests/Unit/Rest/Resources/Customers/AddressResourceTest.php
+++ b/tests/Unit/Rest/Resources/Customers/AddressResourceTest.php
@@ -4,12 +4,18 @@ namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Customers;
 
 use Strawberry\Shopify\Models\Customers\Address;
 use Strawberry\Shopify\Rest\Resources\Customers\AddressResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Rest\Resources\Customers\CustomerResource;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class AddressResourceTest extends ResourceTestCase
+final class AddressResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Address::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [CustomerResource::class, 1053317301],
+    ];
 
     /** @var string */
     protected $resourceClass = AddressResource::class;
@@ -21,9 +27,9 @@ final class AddressResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'customers/123456789/addresses.json');
+        $this->assertRequest('GET', 'customers/1053317301/addresses.json');
         $this->assertCollection($response);
     }
 
@@ -31,12 +37,12 @@ final class AddressResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get([
+        $response = $this->resource->get([
             'limit' => 1,
             'page' => 1,
         ]);
 
-        $this->assertRequest('GET', 'customers/123456789/addresses.json?limit=1&page=1');
+        $this->assertRequest('GET', 'customers/1053317301/addresses.json?limit=1&page=1');
         $this->assertCollection($response);
     }
 
@@ -44,9 +50,9 @@ final class AddressResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(207119551);
+        $response = $this->resource->find(207119551);
 
-        $this->assertRequest('GET', 'customers/123456789/addresses/207119551.json');
+        $this->assertRequest('GET', 'customers/1053317301/addresses/207119551.json');
         $this->assertModel($response);
     }
 
@@ -54,11 +60,11 @@ final class AddressResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'customers/123456789/addresses.json');
+        $this->assertRequest('POST', 'customers/1053317301/addresses.json');
         $this->assertModel($response);
     }
 
@@ -66,12 +72,12 @@ final class AddressResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('update'));
 
-        $response = $this->resource->withParent(123456789)->update(
+        $response = $this->resource->update(
             207119551,
             $this->request('update')
         );
 
-        $this->assertRequest('PUT', 'customers/123456789/addresses/207119551.json');
+        $this->assertRequest('PUT', 'customers/1053317301/addresses/207119551.json');
         $this->assertModel($response);
     }
 
@@ -79,9 +85,9 @@ final class AddressResourceTest extends ResourceTestCase
     {
         $this->queue(200);
 
-        $response = $this->resource->withParent(123456789)->delete(207119551);
+        $response = $this->resource->delete(207119551);
 
-        $this->assertRequest('DELETE', 'customers/123456789/addresses/207119551.json');
+        $this->assertRequest('DELETE', 'customers/1053317301/addresses/207119551.json');
         $this->assertNull($response);
     }
 
@@ -89,27 +95,27 @@ final class AddressResourceTest extends ResourceTestCase
     {
         $this->queue(200);
 
-        $this->resource->withParent(123456789)->bulk([1053317304], 'destroy');
+        $this->resource->bulk([1053317304], 'destroy');
 
-        $this->assertRequest('PUT', 'customers/123456789/addresses/set.json?address_ids[0]=1053317304&operation=destroy');
+        $this->assertRequest('PUT', 'customers/1053317301/addresses/set.json?address_ids[0]=1053317304&operation=destroy');
     }
 
     public function testDeleteMultiple(): void
     {
         $this->queue(200);
 
-        $this->resource->withParent(123456789)->deleteMultiple([1053317304]);
+        $this->resource->deleteMultiple([1053317304]);
 
-        $this->assertRequest('PUT', 'customers/123456789/addresses/set.json?address_ids[0]=1053317304&operation=destroy');
+        $this->assertRequest('PUT', 'customers/1053317301/addresses/set.json?address_ids[0]=1053317304&operation=destroy');
     }
 
     public function testDefault(): void
     {
         $this->queue(200, [], $this->response('default'));
 
-        $response = $this->resource->withParent(123456789)->default(1053317301);
+        $response = $this->resource->default(1053317301);
 
-        $this->assertRequest('PUT', 'customers/123456789/addresses/1053317301/default.json');
+        $this->assertRequest('PUT', 'customers/1053317301/addresses/1053317301/default.json');
         $this->assertModel($response);
     }
 }

--- a/tests/Unit/Rest/Resources/Discounts/BatchResourceTest.php
+++ b/tests/Unit/Rest/Resources/Discounts/BatchResourceTest.php
@@ -6,12 +6,18 @@ use Illuminate\Support\Collection;
 use Strawberry\Shopify\Models\Discounts\Batch;
 use Strawberry\Shopify\Models\Discounts\DiscountCode;
 use Strawberry\Shopify\Rest\Resources\Discounts\BatchResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Rest\Resources\Discounts\PriceRuleResource;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class BatchResourceTest extends ResourceTestCase
+final class BatchResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Batch::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [PriceRuleResource::class, 507328175],
+    ];
 
     /** @var string */
     protected $resourceClass = BatchResource::class;
@@ -23,11 +29,11 @@ final class BatchResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'price_rules/123456789/batch.json');
+        $this->assertRequest('POST', 'price_rules/507328175/batch.json');
         $this->assertModel($response);
     }
 
@@ -35,9 +41,9 @@ final class BatchResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(173232803);
+        $response = $this->resource->find(173232803);
 
-        $this->assertRequest('GET', 'price_rules/123456789/batch/173232803.json');
+        $this->assertRequest('GET', 'price_rules/507328175/batch/173232803.json');
         $this->assertModel($response);
     }
 
@@ -45,9 +51,9 @@ final class BatchResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('discount_codes'));
 
-        $response = $this->resource->withParent(123456789)->discountCodes(987654321);
+        $response = $this->resource->discountCodes(987654321);
 
-        $this->assertRequest('GET', 'price_rules/123456789/batch/987654321/discount_codes.json');
+        $this->assertRequest('GET', 'price_rules/507328175/batch/987654321/discount_codes.json');
         $this->assertInstanceOf(Collection::class, $response);
         $this->assertContainsOnlyInstancesOf(DiscountCode::class, $response);
     }

--- a/tests/Unit/Rest/Resources/Discounts/DiscountCodeResourceTest.php
+++ b/tests/Unit/Rest/Resources/Discounts/DiscountCodeResourceTest.php
@@ -4,12 +4,18 @@ namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Discounts;
 
 use Strawberry\Shopify\Models\Discounts\DiscountCode;
 use Strawberry\Shopify\Rest\Resources\Discounts\DiscountCodeResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Rest\Resources\Discounts\PriceRuleResource;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class DiscountCodeResourceTest extends ResourceTestCase
+final class DiscountCodeResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = DiscountCode::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [PriceRuleResource::class, 123456789],
+    ];
 
     /** @var string */
     protected $resourceClass = DiscountCodeResource::class;
@@ -21,7 +27,7 @@ final class DiscountCodeResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
         $this->assertRequest('GET', 'price_rules/123456789/discount_codes.json');
         $this->assertCollection($response);
@@ -31,7 +37,7 @@ final class DiscountCodeResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(507328175);
+        $response = $this->resource->find(507328175);
 
         $this->assertRequest('GET', 'price_rules/123456789/discount_codes/507328175.json');
         $this->assertModel($response);
@@ -41,7 +47,7 @@ final class DiscountCodeResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
@@ -53,7 +59,7 @@ final class DiscountCodeResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('update'));
 
-        $response = $this->resource->withParent(123456789)->update(
+        $response = $this->resource->update(
             507328175,
             $this->request('update')
         );
@@ -66,7 +72,7 @@ final class DiscountCodeResourceTest extends ResourceTestCase
     {
         $this->queue(200);
 
-        $response = $this->resource->withParent(123456789)->delete(507328175);
+        $response = $this->resource->delete(507328175);
 
         $this->assertRequest('DELETE', 'price_rules/123456789/discount_codes/507328175.json');
         $this->assertNull($response);

--- a/tests/Unit/Rest/Resources/OnlineStore/AssetResourceTest.php
+++ b/tests/Unit/Rest/Resources/OnlineStore/AssetResourceTest.php
@@ -4,12 +4,18 @@ namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\OnlineStore;
 
 use Strawberry\Shopify\Models\OnlineStore\Asset;
 use Strawberry\Shopify\Rest\Resources\OnlineStore\AssetResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Rest\Resources\OnlineStore\ThemeResource;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class AssetResourceTest extends ResourceTestCase
+final class AssetResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Asset::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [ThemeResource::class, 828155753],
+    ];
 
     /** @var string */
     protected $resourceClass = AssetResource::class;
@@ -21,9 +27,9 @@ final class AssetResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'themes/123456789/assets.json');
+        $this->assertRequest('GET', 'themes/828155753/assets.json');
         $this->assertCollection($response, 27);
     }
 
@@ -31,9 +37,9 @@ final class AssetResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find('templates/index.liquid');
+        $response = $this->resource->find('templates/index.liquid');
 
-        $this->assertRequest('GET', 'themes/123456789/assets.json?asset[key]=templates/index.liquid');
+        $this->assertRequest('GET', 'themes/828155753/assets.json?asset[key]=templates/index.liquid');
         $this->assertModel($response);
     }
 
@@ -41,11 +47,11 @@ final class AssetResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('create_or_update'));
 
-        $response = $this->resource->withParent(123456789)->createOrUpdate(
+        $response = $this->resource->createOrUpdate(
             $this->request('create_or_update')
         );
 
-        $this->assertRequest('PUT', 'themes/123456789/assets.json');
+        $this->assertRequest('PUT', 'themes/828155753/assets.json');
         $this->assertModel($response);
     }
 
@@ -53,9 +59,9 @@ final class AssetResourceTest extends ResourceTestCase
     {
         $this->queue(200);
 
-        $response = $this->resource->withParent(123456789)->delete('assets/bg-body.gif');
+        $response = $this->resource->delete('assets/bg-body.gif');
 
-        $this->assertRequest('DELETE', 'themes/123456789/assets.json?asset[key]=assets/bg-body.gif');
+        $this->assertRequest('DELETE', 'themes/828155753/assets.json?asset[key]=assets/bg-body.gif');
         $this->assertNull($response);
     }
 
@@ -63,12 +69,12 @@ final class AssetResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('create_or_update'));
 
-        $response = $this->resource->withParent(123456789)->upload(
+        $response = $this->resource->upload(
             'templates/index.liquid',
             "<img src='backsoon-postit.png'><p>We are busy updating the store for you and will be back within the hour.</p>"
         );
 
-        $this->assertRequest('PUT', 'themes/123456789/assets.json');
+        $this->assertRequest('PUT', 'themes/828155753/assets.json');
         $this->assertModel($response);
     }
 
@@ -76,12 +82,12 @@ final class AssetResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('create_or_update'));
 
-        $response = $this->resource->withParent(123456789)->uploadFromBase64(
+        $response = $this->resource->uploadFromBase64(
             'assets/empty.gif',
             'R0lGODlhAQABAPABAP///wAAACH5BAEKAAAALAAAAAABAAEAAAICRAEAOw==\n'
         );
 
-        $this->assertRequest('PUT', 'themes/123456789/assets.json');
+        $this->assertRequest('PUT', 'themes/828155753/assets.json');
         $this->assertModel($response);
     }
 
@@ -89,12 +95,12 @@ final class AssetResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('create_or_update'));
 
-        $response = $this->resource->withParent(123456789)->uploadFromUrl(
+        $response = $this->resource->uploadFromUrl(
             'assets/bg-body.gif',
             'http://apple.com/new_bg.gif'
         );
 
-        $this->assertRequest('PUT', 'themes/123456789/assets.json');
+        $this->assertRequest('PUT', 'themes/828155753/assets.json');
         $this->assertModel($response);
     }
 
@@ -102,12 +108,12 @@ final class AssetResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('create_or_update'));
 
-        $response = $this->resource->withParent(123456789)->duplicate(
+        $response = $this->resource->duplicate(
             'layout/alternate.liquid',
             'layout/theme.liquid'
         );
 
-        $this->assertRequest('PUT', 'themes/123456789/assets.json');
+        $this->assertRequest('PUT', 'themes/828155753/assets.json');
         $this->assertModel($response);
     }
 }

--- a/tests/Unit/Rest/Resources/OnlineStore/BlogArticleResourceTest.php
+++ b/tests/Unit/Rest/Resources/OnlineStore/BlogArticleResourceTest.php
@@ -4,12 +4,18 @@ namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\OnlineStore;
 
 use Strawberry\Shopify\Models\OnlineStore\Article;
 use Strawberry\Shopify\Rest\Resources\OnlineStore\BlogArticleResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Rest\Resources\OnlineStore\BlogResource;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class BlogArticleResourceTest extends ResourceTestCase
+final class BlogArticleResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Article::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [BlogResource::class, 241253187],
+    ];
 
     /** @var string */
     protected $resourceClass = BlogArticleResource::class;
@@ -21,9 +27,9 @@ final class BlogArticleResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'blogs/123456789/articles.json');
+        $this->assertRequest('GET', 'blogs/241253187/articles.json');
         $this->assertCollection($response, 4);
     }
 
@@ -31,9 +37,9 @@ final class BlogArticleResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(998730532);
+        $response = $this->resource->find(998730532);
 
-        $this->assertRequest('GET', 'blogs/123456789/articles/998730532.json');
+        $this->assertRequest('GET', 'blogs/241253187/articles/998730532.json');
         $this->assertModel($response);
     }
 
@@ -41,11 +47,11 @@ final class BlogArticleResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'blogs/123456789/articles.json');
+        $this->assertRequest('POST', 'blogs/241253187/articles.json');
         $this->assertModel($response);
     }
 
@@ -53,12 +59,12 @@ final class BlogArticleResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('update'));
 
-        $response = $this->resource->withParent(123456789)->update(
+        $response = $this->resource->update(
             998730532,
             $this->request('update')
         );
 
-        $this->assertRequest('PUT', 'blogs/123456789/articles/998730532.json');
+        $this->assertRequest('PUT', 'blogs/241253187/articles/998730532.json');
         $this->assertModel($response);
     }
 
@@ -66,9 +72,9 @@ final class BlogArticleResourceTest extends ResourceTestCase
     {
         $this->queue(200);
 
-        $response = $this->resource->withParent(123456789)->delete(998730532);
+        $response = $this->resource->delete(998730532);
 
-        $this->assertRequest('DELETE', 'blogs/123456789/articles/998730532.json');
+        $this->assertRequest('DELETE', 'blogs/241253187/articles/998730532.json');
         $this->assertNull($response);
     }
 
@@ -76,9 +82,9 @@ final class BlogArticleResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('count'));
 
-        $response = $this->resource->withParent(123456789)->count();
+        $response = $this->resource->count();
 
-        $this->assertRequest('GET', 'blogs/123456789/articles/count.json');
+        $this->assertRequest('GET', 'blogs/241253187/articles/count.json');
         $this->assertSame(4, $response);
     }
 
@@ -86,9 +92,9 @@ final class BlogArticleResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('tags'));
 
-        $response = $this->resource->withParent(123456789)->tags();
+        $response = $this->resource->tags();
 
-        $this->assertRequest('GET', 'blogs/123456789/articles/tags.json');
+        $this->assertRequest('GET', 'blogs/241253187/articles/tags.json');
         $this->assertSame([
             'Announcing', 'Mystery'
         ], $response);

--- a/tests/Unit/Rest/Resources/OnlineStore/BlogResourceTest.php
+++ b/tests/Unit/Rest/Resources/OnlineStore/BlogResourceTest.php
@@ -3,6 +3,8 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\OnlineStore;
 
 use Strawberry\Shopify\Models\OnlineStore\Blog;
+use Strawberry\Shopify\Rest\Resources\OnlineStore\ArticleResource;
+use Strawberry\Shopify\Rest\Resources\OnlineStore\BlogArticleResource;
 use Strawberry\Shopify\Rest\Resources\OnlineStore\BlogResource;
 use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
 
@@ -16,6 +18,12 @@ final class BlogResourceTest extends ResourceTestCase
 
     /** @var string */
     protected $dataPath = 'online_store/blog';
+
+    public function testChildren(): void
+    {
+        $this->assertTrue($this->resource->hasChildren());
+        $this->assertChild('articles', BlogArticleResource::class);
+    }
 
     public function testGet(): void
     {

--- a/tests/Unit/Rest/Resources/Orders/OrderResourceTest.php
+++ b/tests/Unit/Rest/Resources/Orders/OrderResourceTest.php
@@ -4,6 +4,10 @@ namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Orders;
 
 use Strawberry\Shopify\Models\Orders\Order;
 use Strawberry\Shopify\Rest\Resources\Orders\OrderResource;
+use Strawberry\Shopify\Rest\Resources\Orders\OrderRiskResource;
+use Strawberry\Shopify\Rest\Resources\Orders\RefundResource;
+use Strawberry\Shopify\Rest\Resources\Orders\TransactionResource;
+use Strawberry\Shopify\Rest\Resources\Shipping\FulfillmentResource;
 use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
 
 final class OrderResourceTest extends ResourceTestCase
@@ -16,6 +20,15 @@ final class OrderResourceTest extends ResourceTestCase
 
     /** @var string */
     protected $dataPath = 'orders/order';
+
+    public function testChildren(): void
+    {
+        $this->assertTrue($this->resource->hasChildren());
+        $this->assertChild('fulfillments', FulfillmentResource::class);
+        $this->assertChild('refunds', RefundResource::class);
+        $this->assertChild('risks', OrderRiskResource::class);
+        $this->assertChild('transactions', TransactionResource::class);
+    }
 
     public function testGet(): void
     {

--- a/tests/Unit/Rest/Resources/Orders/OrderRiskResourceTest.php
+++ b/tests/Unit/Rest/Resources/Orders/OrderRiskResourceTest.php
@@ -3,13 +3,19 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Orders;
 
 use Strawberry\Shopify\Models\Orders\OrderRisk;
+use Strawberry\Shopify\Rest\Resources\Orders\OrderResource;
 use Strawberry\Shopify\Rest\Resources\Orders\OrderRiskResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class OrderRiskResourceTest extends ResourceTestCase
+final class OrderRiskResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = OrderRisk::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [OrderResource::class, 450789469],
+    ];
 
     /** @var string */
     protected $resourceClass = OrderRiskResource::class;
@@ -21,9 +27,9 @@ final class OrderRiskResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'orders/123456789/risks.json');
+        $this->assertRequest('GET', 'orders/450789469/risks.json');
         $this->assertCollection($response, 2);
     }
 
@@ -31,9 +37,9 @@ final class OrderRiskResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(284138680);
+        $response = $this->resource->find(284138680);
 
-        $this->assertRequest('GET', 'orders/123456789/risks/284138680.json');
+        $this->assertRequest('GET', 'orders/450789469/risks/284138680.json');
         $this->assertModel($response);
     }
 
@@ -41,11 +47,11 @@ final class OrderRiskResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'orders/123456789/risks.json');
+        $this->assertRequest('POST', 'orders/450789469/risks.json');
         $this->assertModel($response);
     }
 
@@ -53,12 +59,12 @@ final class OrderRiskResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('update'));
 
-        $response = $this->resource->withParent(123456789)->update(
+        $response = $this->resource->update(
             284138680,
             $this->request('update')
         );
 
-        $this->assertRequest('PUT', 'orders/123456789/risks/284138680.json');
+        $this->assertRequest('PUT', 'orders/450789469/risks/284138680.json');
         $this->assertModel($response);
     }
 
@@ -66,9 +72,9 @@ final class OrderRiskResourceTest extends ResourceTestCase
     {
         $this->queue(200);
 
-        $response = $this->resource->withParent(123456789)->delete(284138680);
+        $response = $this->resource->delete(284138680);
 
-        $this->assertRequest('DELETE', 'orders/123456789/risks/284138680.json');
+        $this->assertRequest('DELETE', 'orders/450789469/risks/284138680.json');
         $this->assertNull($response);
     }
 }

--- a/tests/Unit/Rest/Resources/Orders/RefundResourceTest.php
+++ b/tests/Unit/Rest/Resources/Orders/RefundResourceTest.php
@@ -3,13 +3,19 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Orders;
 
 use Strawberry\Shopify\Models\Orders\Refund;
+use Strawberry\Shopify\Rest\Resources\Orders\OrderResource;
 use Strawberry\Shopify\Rest\Resources\Orders\RefundResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class RefundResourceTest extends ResourceTestCase
+final class RefundResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Refund::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [OrderResource::class, 450789469],
+    ];
 
     /** @var string */
     protected $resourceClass = RefundResource::class;
@@ -21,9 +27,9 @@ final class RefundResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'orders/123456789/refunds.json');
+        $this->assertRequest('GET', 'orders/450789469/refunds.json');
         $this->assertCollection($response, 1);
     }
 
@@ -31,9 +37,9 @@ final class RefundResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(509562969);
+        $response = $this->resource->find(509562969);
 
-        $this->assertRequest('GET', 'orders/123456789/refunds/509562969.json');
+        $this->assertRequest('GET', 'orders/450789469/refunds/509562969.json');
         $this->assertModel($response);
     }
 
@@ -41,11 +47,11 @@ final class RefundResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'orders/123456789/refunds.json');
+        $this->assertRequest('POST', 'orders/450789469/refunds.json');
         $this->assertModel($response);
     }
 
@@ -53,11 +59,11 @@ final class RefundResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('calculate'));
 
-        $response = $this->resource->withParent(123456789)->calculate(
+        $response = $this->resource->calculate(
             $this->request('calculate')
         );
 
-        $this->assertRequest('POST', 'orders/123456789/refunds/calculate.json');
+        $this->assertRequest('POST', 'orders/450789469/refunds/calculate.json');
         $this->assertModel($response);
     }
 }

--- a/tests/Unit/Rest/Resources/Orders/TransactionResourceTest.php
+++ b/tests/Unit/Rest/Resources/Orders/TransactionResourceTest.php
@@ -3,13 +3,19 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Orders;
 
 use Strawberry\Shopify\Models\Orders\Transaction;
+use Strawberry\Shopify\Rest\Resources\Orders\OrderResource;
 use Strawberry\Shopify\Rest\Resources\Orders\TransactionResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class TransactionResourceTest extends ResourceTestCase
+final class TransactionResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Transaction::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [OrderResource::class, 450789469],
+    ];
 
     /** @var string */
     protected $resourceClass = TransactionResource::class;
@@ -21,9 +27,9 @@ final class TransactionResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'orders/123456789/transactions.json');
+        $this->assertRequest('GET', 'orders/450789469/transactions.json');
         $this->assertCollection($response, 3);
     }
 
@@ -31,9 +37,9 @@ final class TransactionResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(284138680);
+        $response = $this->resource->find(284138680);
 
-        $this->assertRequest('GET', 'orders/123456789/transactions/284138680.json');
+        $this->assertRequest('GET', 'orders/450789469/transactions/284138680.json');
         $this->assertModel($response);
     }
 
@@ -41,11 +47,11 @@ final class TransactionResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'orders/123456789/transactions.json');
+        $this->assertRequest('POST', 'orders/450789469/transactions.json');
         $this->assertModel($response);
     }
 
@@ -53,9 +59,9 @@ final class TransactionResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('count'));
 
-        $response = $this->resource->withParent(123456789)->count();
+        $response = $this->resource->count();
 
-        $this->assertRequest('GET', 'orders/123456789/transactions/count.json');
+        $this->assertRequest('GET', 'orders/450789469/transactions/count.json');
         $this->assertSame(3, $response);
     }
 }

--- a/tests/Unit/Rest/Resources/Products/ImageResourceTest.php
+++ b/tests/Unit/Rest/Resources/Products/ImageResourceTest.php
@@ -4,12 +4,18 @@ namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Products;
 
 use Strawberry\Shopify\Models\Products\Image;
 use Strawberry\Shopify\Rest\Resources\Products\ImageResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Rest\Resources\Products\ProductResource;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class ImageResourceTest extends ResourceTestCase
+final class ImageResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Image::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [ProductResource::class, 632910392],
+    ];
 
     /** @var string */
     protected $resourceClass = ImageResource::class;
@@ -21,9 +27,9 @@ final class ImageResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'products/123456789/images.json');
+        $this->assertRequest('GET', 'products/632910392/images.json');
         $this->assertCollection($response, 2);
     }
 
@@ -31,9 +37,9 @@ final class ImageResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(632910392);
+        $response = $this->resource->find(632910392);
 
-        $this->assertRequest('GET', 'products/123456789/images/632910392.json');
+        $this->assertRequest('GET', 'products/632910392/images/632910392.json');
         $this->assertModel($response);
     }
 
@@ -41,11 +47,11 @@ final class ImageResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'products/123456789/images.json');
+        $this->assertRequest('POST', 'products/632910392/images.json');
         $this->assertModel($response);
     }
 
@@ -53,12 +59,12 @@ final class ImageResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('update'));
 
-        $response = $this->resource->withParent(123456789)->update(
+        $response = $this->resource->update(
             632910392,
             $this->request('update')
         );
 
-        $this->assertRequest('PUT', 'products/123456789/images/632910392.json');
+        $this->assertRequest('PUT', 'products/632910392/images/632910392.json');
         $this->assertModel($response);
     }
 
@@ -66,9 +72,9 @@ final class ImageResourceTest extends ResourceTestCase
     {
         $this->queue(200);
 
-        $response = $this->resource->withParent(123456789)->delete(632910392);
+        $response = $this->resource->delete(632910392);
 
-        $this->assertRequest('DELETE', 'products/123456789/images/632910392.json');
+        $this->assertRequest('DELETE', 'products/632910392/images/632910392.json');
         $this->assertNull($response);
     }
 
@@ -76,9 +82,9 @@ final class ImageResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('count'));
 
-        $response = $this->resource->withParent(123456789)->count();
+        $response = $this->resource->count();
 
-        $this->assertRequest('GET', 'products/123456789/images/count.json');
+        $this->assertRequest('GET', 'products/632910392/images/count.json');
         $this->assertSame(2, $response);
     }
 }

--- a/tests/Unit/Rest/Resources/Products/ProductVariantResourceTest.php
+++ b/tests/Unit/Rest/Resources/Products/ProductVariantResourceTest.php
@@ -3,13 +3,19 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Products;
 
 use Strawberry\Shopify\Models\Products\Variant;
+use Strawberry\Shopify\Rest\Resources\Products\ProductResource;
 use Strawberry\Shopify\Rest\Resources\Products\ProductVariantResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class ProductVariantResourceTest extends ResourceTestCase
+final class ProductVariantResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Variant::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [ProductResource::class, 632910392],
+    ];
 
     /** @var string */
     protected $resourceClass = ProductVariantResource::class;
@@ -21,9 +27,9 @@ final class ProductVariantResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'products/123456789/variants.json');
+        $this->assertRequest('GET', 'products/632910392/variants.json');
         $this->assertCollection($response, 4);
     }
 
@@ -31,11 +37,11 @@ final class ProductVariantResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'products/123456789/variants.json');
+        $this->assertRequest('POST', 'products/632910392/variants.json');
         $this->assertModel($response);
     }
 
@@ -43,9 +49,9 @@ final class ProductVariantResourceTest extends ResourceTestCase
     {
         $this->queue(200);
 
-        $response = $this->resource->withParent(123456789)->delete(808950810);
+        $response = $this->resource->delete(808950810);
 
-        $this->assertRequest('DELETE', 'products/123456789/variants/808950810.json');
+        $this->assertRequest('DELETE', 'products/632910392/variants/808950810.json');
         $this->assertNull($response);
     }
 
@@ -53,9 +59,9 @@ final class ProductVariantResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('count'));
 
-        $response = $this->resource->withParent(123456789)->count();
+        $response = $this->resource->count();
 
-        $this->assertRequest('GET', 'products/123456789/variants/count.json');
+        $this->assertRequest('GET', 'products/632910392/variants/count.json');
         $this->assertSame(4, $response);
     }
 }

--- a/tests/Unit/Rest/Resources/ResourceTestCase.php
+++ b/tests/Unit/Rest/Resources/ResourceTestCase.php
@@ -83,6 +83,6 @@ abstract class ResourceTestCase extends TestCase
     protected function assertChild(string $key, string $class): void
     {
         $this->assertTrue($this->resource->hasChild($key));
-        $this->assertInstanceOf($class, $this->resource->getChild($key));
+        $this->assertInstanceOf($class, $this->resource->getChild($key, 1));
     }
 }

--- a/tests/Unit/Rest/Resources/Sales/CheckoutResourceTest.php
+++ b/tests/Unit/Rest/Resources/Sales/CheckoutResourceTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Strawberry\Shopify\Models\Sales\Checkout;
 use Strawberry\Shopify\Models\Sales\ShippingRate;
 use Strawberry\Shopify\Rest\Resources\Sales\CheckoutResource;
+use Strawberry\Shopify\Rest\Resources\Sales\PaymentResource;
 use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
 
 final class CheckoutResourceTest extends ResourceTestCase
@@ -18,6 +19,12 @@ final class CheckoutResourceTest extends ResourceTestCase
 
     /** @var string */
     protected $dataPath = 'sales/checkout';
+
+    public function testChildren(): void
+    {
+        $this->assertTrue($this->resource->hasChildren());
+        $this->assertChild('payments', PaymentResource::class);
+    }
 
     public function testCreate(): void
     {

--- a/tests/Unit/Rest/Resources/Sales/PaymentResourceTest.php
+++ b/tests/Unit/Rest/Resources/Sales/PaymentResourceTest.php
@@ -3,13 +3,19 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Sales;
 
 use Strawberry\Shopify\Models\Sales\Payment;
+use Strawberry\Shopify\Rest\Resources\Sales\CheckoutResource;
 use Strawberry\Shopify\Rest\Resources\Sales\PaymentResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class PaymentResourceTest extends ResourceTestCase
+final class PaymentResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Payment::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [CheckoutResource::class, '7yjf4v2we7gamku6a6h7tvm8h3mmvs4x'],
+    ];
 
     /** @var string */
     protected $resourceClass = PaymentResource::class;
@@ -21,7 +27,7 @@ final class PaymentResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent('7yjf4v2we7gamku6a6h7tvm8h3mmvs4x')->get();
+        $response = $this->resource->get();
 
         $this->assertRequest('GET', 'checkouts/7yjf4v2we7gamku6a6h7tvm8h3mmvs4x/payments.json');
         $this->assertCollection($response, 1);
@@ -31,7 +37,7 @@ final class PaymentResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent('7yjf4v2we7gamku6a6h7tvm8h3mmvs4x')->find(25428999);
+        $response = $this->resource->find(25428999);
 
         $this->assertRequest('GET', 'checkouts/7yjf4v2we7gamku6a6h7tvm8h3mmvs4x/payments/25428999.json');
         $this->assertModel($response);
@@ -41,7 +47,7 @@ final class PaymentResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent('7yjf4v2we7gamku6a6h7tvm8h3mmvs4x')->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
@@ -53,7 +59,7 @@ final class PaymentResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('count'));
 
-        $response = $this->resource->withParent('7yjf4v2we7gamku6a6h7tvm8h3mmvs4x')->count();
+        $response = $this->resource->count();
 
         $this->assertRequest('GET', 'checkouts/7yjf4v2we7gamku6a6h7tvm8h3mmvs4x/payments/count.json');
         $this->assertSame(1, $response);

--- a/tests/Unit/Rest/Resources/Shipping/FulfillmentEventResourceTest.php
+++ b/tests/Unit/Rest/Resources/Shipping/FulfillmentEventResourceTest.php
@@ -3,17 +3,67 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Shipping;
 
 use Strawberry\Shopify\Models\Shipping\FulfillmentEvent;
+use Strawberry\Shopify\Rest\Resources\Orders\OrderResource;
 use Strawberry\Shopify\Rest\Resources\Shipping\FulfillmentEventResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Rest\Resources\Shipping\FulfillmentResource;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class FulfillmentEventResourceTest extends ResourceTestCase
+final class FulfillmentEventResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = FulfillmentEvent::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [OrderResource::class, 450789469],
+        [FulfillmentResource::class, 255858046],
+    ];
 
     /** @var string */
     protected $resourceClass = FulfillmentEventResource::class;
 
     /** @var string */
     protected $dataPath = 'shipping/fulfillment_event';
+
+    public function testGet(): void
+    {
+        $this->queue(200, [], $this->response('get'));
+
+        $response = $this->resource->get();
+
+        $this->assertRequest('GET', 'orders/450789469/fulfillments/255858046/events.json');
+        $this->assertCollection($response, 1);
+    }
+
+    public function testFind(): void
+    {
+        $this->queue(200, [], $this->response('find'));
+
+        $response = $this->resource->find(944956392);
+
+        $this->assertRequest('GET', 'orders/450789469/fulfillments/255858046/events/944956392.json');
+        $this->assertModel($response);
+    }
+
+    public function testCreate(): void
+    {
+        $this->queue(201, [], $this->response('create'));
+
+        $response = $this->resource->create(
+            $this->response('create')
+        );
+
+        $this->assertRequest('POST', 'orders/450789469/fulfillments/255858046/events.json');
+        $this->assertModel($response);
+    }
+
+    public function testDelete(): void
+    {
+        $this->queue(200);
+
+        $response = $this->resource->delete(944956394);
+
+        $this->assertRequest('DELETE', 'orders/450789469/fulfillments/255858046/events/944956394.json');
+        $this->assertNull($response);
+    }
 }

--- a/tests/Unit/Rest/Resources/Shipping/FulfillmentResourceTest.php
+++ b/tests/Unit/Rest/Resources/Shipping/FulfillmentResourceTest.php
@@ -4,6 +4,7 @@ namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Shipping;
 
 use Strawberry\Shopify\Models\Shipping\Fulfillment;
 use Strawberry\Shopify\Rest\Resources\Orders\OrderResource;
+use Strawberry\Shopify\Rest\Resources\Shipping\FulfillmentEventResource;
 use Strawberry\Shopify\Rest\Resources\Shipping\FulfillmentResource;
 use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
@@ -22,6 +23,12 @@ final class FulfillmentResourceTest extends ChildResourceTestCase
 
     /** @var string */
     protected $dataPath = 'shipping/fulfillment';
+
+    public function testChildren(): void
+    {
+        $this->assertTrue($this->resource->hasChildren());
+        $this->assertChild('events', FulfillmentEventResource::class);
+    }
 
     public function testGet(): void
     {

--- a/tests/Unit/Rest/Resources/Shipping/FulfillmentResourceTest.php
+++ b/tests/Unit/Rest/Resources/Shipping/FulfillmentResourceTest.php
@@ -3,13 +3,19 @@
 namespace Strawberry\Shopify\Tests\Unit\Rest\Resources\Shipping;
 
 use Strawberry\Shopify\Models\Shipping\Fulfillment;
+use Strawberry\Shopify\Rest\Resources\Orders\OrderResource;
 use Strawberry\Shopify\Rest\Resources\Shipping\FulfillmentResource;
-use Strawberry\Shopify\Tests\Unit\Rest\Resources\ResourceTestCase;
+use Strawberry\Shopify\Tests\Unit\Rest\Resources\ChildResourceTestCase;
 
-final class FulfillmentResourceTest extends ResourceTestCase
+final class FulfillmentResourceTest extends ChildResourceTestCase
 {
     /** @var string */
     protected $modelClass = Fulfillment::class;
+
+    /** @var array */
+    protected $parentResources = [
+        [OrderResource::class, 450789469],
+    ];
 
     /** @var string */
     protected $resourceClass = FulfillmentResource::class;
@@ -21,9 +27,9 @@ final class FulfillmentResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('get'));
 
-        $response = $this->resource->withParent(123456789)->get();
+        $response = $this->resource->get();
 
-        $this->assertRequest('GET', 'orders/123456789/fulfillments.json');
+        $this->assertRequest('GET', 'orders/450789469/fulfillments.json');
         $this->assertCollection($response);
     }
 
@@ -31,9 +37,9 @@ final class FulfillmentResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('find'));
 
-        $response = $this->resource->withParent(123456789)->find(450789469);
+        $response = $this->resource->find(450789469);
 
-        $this->assertRequest('GET', 'orders/123456789/fulfillments/450789469.json');
+        $this->assertRequest('GET', 'orders/450789469/fulfillments/450789469.json');
         $this->assertModel($response);
     }
 
@@ -41,11 +47,11 @@ final class FulfillmentResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('create'));
 
-        $response = $this->resource->withParent(123456789)->create(
+        $response = $this->resource->create(
             $this->request('create')
         );
 
-        $this->assertRequest('POST', 'orders/123456789/fulfillments.json');
+        $this->assertRequest('POST', 'orders/450789469/fulfillments.json');
         $this->assertModel($response);
     }
 
@@ -53,12 +59,12 @@ final class FulfillmentResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('update'));
 
-        $response = $this->resource->withParent(123456789)->update(
+        $response = $this->resource->update(
             450789469,
             $this->request('update')
         );
 
-        $this->assertRequest('PUT', 'orders/123456789/fulfillments/450789469.json');
+        $this->assertRequest('PUT', 'orders/450789469/fulfillments/450789469.json');
         $this->assertModel($response);
     }
 
@@ -66,9 +72,9 @@ final class FulfillmentResourceTest extends ResourceTestCase
     {
         $this->queue(200, [], $this->response('count'));
 
-        $response = $this->resource->withParent(123456789)->count();
+        $response = $this->resource->count();
 
-        $this->assertRequest('GET', 'orders/123456789/fulfillments/count.json');
+        $this->assertRequest('GET', 'orders/450789469/fulfillments/count.json');
         $this->assertSame(1, $response);
     }
 
@@ -76,9 +82,9 @@ final class FulfillmentResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('complete'));
 
-        $response = $this->resource->withParent(123456789)->complete(255858046);
+        $response = $this->resource->complete(255858046);
 
-        $this->assertRequest('POST', 'orders/123456789/fulfillments/255858046/complete.json');
+        $this->assertRequest('POST', 'orders/450789469/fulfillments/255858046/complete.json');
         $this->assertModel($response);
     }
 
@@ -86,9 +92,9 @@ final class FulfillmentResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('open'));
 
-        $response = $this->resource->withParent(123456789)->open(255858046);
+        $response = $this->resource->open(255858046);
 
-        $this->assertRequest('POST', 'orders/123456789/fulfillments/255858046/open.json');
+        $this->assertRequest('POST', 'orders/450789469/fulfillments/255858046/open.json');
         $this->assertModel($response);
     }
 
@@ -96,9 +102,9 @@ final class FulfillmentResourceTest extends ResourceTestCase
     {
         $this->queue(201, [], $this->response('cancel'));
 
-        $response = $this->resource->withParent(123456789)->cancel(255858046);
+        $response = $this->resource->cancel(255858046);
 
-        $this->assertRequest('POST', 'orders/123456789/fulfillments/255858046/cancel.json');
+        $this->assertRequest('POST', 'orders/450789469/fulfillments/255858046/cancel.json');
         $this->assertModel($response);
     }
 }


### PR DESCRIPTION
Child resources now require a parent instance and a parent ID on instantiation—this allows for multi-level parent resources (e.g. Order -> Fulfillment -> Fulfillment Event).